### PR TITLE
SDL Audio init on Windows

### DIFF
--- a/src/liblgx/liblgx-common/src/sdl/SdlAudioOutput.cpp
+++ b/src/liblgx/liblgx-common/src/sdl/SdlAudioOutput.cpp
@@ -11,14 +11,13 @@ namespace sdl {
 
     void SdlAudioOutput::initialiseAudio() {
         SDL_AudioSpec want, have;
-
-        SDL_memset(&want, 0, sizeof(want));
+        SDL_zero(want);
         want.freq = 48000;
         want.format = AUDIO_S16LSB;
         want.channels = 2;
         want.samples = 1024;
         want.callback = nullptr;
-        _audio = SDL_OpenAudioDevice(nullptr, 0, &want, &have, SDL_AUDIO_ALLOW_FORMAT_CHANGE);
+        _audio = SDL_OpenAudioDevice(nullptr, 0, &want, &have, 0); //SDL_AUDIO_ALLOW_FORMAT_CHANGE
         SDL_PauseAudioDevice(_audio, 0);
     }
 

--- a/src/liblgx/liblgx-common/src/sdl/SdlAudioOutput.cpp
+++ b/src/liblgx/liblgx-common/src/sdl/SdlAudioOutput.cpp
@@ -17,7 +17,7 @@ namespace sdl {
         want.channels = 2;
         want.samples = 1024;
         want.callback = nullptr;
-        _audio = SDL_OpenAudioDevice(nullptr, 0, &want, &have, 0); //SDL_AUDIO_ALLOW_FORMAT_CHANGE
+        _audio = SDL_OpenAudioDevice(nullptr, 0, &want, &have, 0);
         SDL_PauseAudioDevice(_audio, 0);
     }
 


### PR DESCRIPTION
Seem like on Sindows using flag `SDL_AUDIO_ALLOW_FORMAT_CHANGE` in SDL audio init cause it to be broken. 
without it, audio can be heard, still garbage but as video seem to be broken at the moment I can not be sure if that nothing external. 
This is offered as "hey try this maybe it work better" 
also `SDL_memset(&want, 0, sizeof(want));` could be simplified with `SDL_zero(want)` 
It need to be tested on Linux and MacOS